### PR TITLE
Drop superfluous at sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If a forked Rails project can meet these criteria, we pledge to support and chee
 |Joe Sak|-|[@joesak.com](https://bsky.app/profile/joesak.com)
 |Jochen Lillich|-|[@monospace@floss.social](https://floss.social/@monospace)|
 |John-Paul Teti|-|[@jpteti@mastodon.social](https://mastodon.social/@jpteti)|
-|John Small|-|@jds340@gmail.com|
+|John Small|-|jds340@gmail.com|
 |Jon Wood|-|[@jon@blankpad.net](https://activitypub.blankpad.net/@jon@blankpad.net/)|
 |Jonathon Anderson|-|[@anderson_jon@hachyderm.io](https://hachyderm.io/@anderson_jon)|
 |Dr Kim Foale|[Geeks for Social Change](https://gfsc.community/)|[kim@social.gfsc.studio](https://social.gfsc.studio/@kim)


### PR DESCRIPTION
The corresponding entry is an email address, not a Fediverse handle, and hence should not have a leading at sign.