### PR TITLE
Fix: Replace archive.org links with direct links to original source

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If a forked Rails project can meet these criteria, we pledge to support and chee
 
 * ["Plan Vert"](https://en.wikipedia.org/wiki/Railway_sabotage_during_World_War_II#France) was a railway sabotage campaign by the French resistance during WW2. Reference suggested by [@cinebox@masto.hackers.town](https://masto.hackers.town/@cinebox/115210459164892947).
 
-* DHH's writings are available on [his blog](https://web.archive.org/web/20250920182553/world.hey.com/dhh); we link the archive.org mirror rather than send traffic his way.
++ DHH's writings are available on [his blog](https://world.hey.com/dhh).
 
 * Many people have written their own thoughts on the problems with DHH's influence in Rails and the wider Ruby community (which is not a new problem, but is reaching new levels). Here's a selection:
   * [David Celis: Rails Needs New Governance](https://davidcel.is/articles/rails-needs-new-governance)


### PR DESCRIPTION
Using archive.org mirrors without the copyright holder's permission may violate their exclusive rights to control content distribution. Regardless of how objectionable we find someone's views, disagreement does not justify circumventing their intellectual property rights. Linking to original sources while providing our own analysis respects both copyright law and principles of fair discourse.

This change focuses solely on copyright compliance and does not reflect any position on the substantive content expressed.