### PR TITLE
Why?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plan Vert
+# Plan Vert 
 ## An open letter to the Rails Core team and Ruby community
 
 David Heinemeier Hansson (DHH) has publicly published writings that make clear he holds [racist](https://web.archive.org/web/20250920182553/http://world.hey.com/dhh/as-i-remember-london-e7d38e64) and [transphobic](https://web.archive.org/web/20250920061926/https://world.hey.com/dhh/gender-and-sexuality-alliances-in-primary-school-at-cis-97f66c06) views, as well as a number of other traits [undesirable](https://tomstu.art/the-dhh-problem) in any figurehead and community leader.


### PR DESCRIPTION
DHH has done so much to the community.

This platform, github, ran on rails as a direct result of DHH's vision and commitment to make the world a better place with rails.

Sure, he is opinionated and harsh, but is this how you repay him?

Why attack someone just because you don't like their views? Why do you want to cancel him from rails? How is rails even relevant to his views?